### PR TITLE
Fix checkpoint loading across platforms

### DIFF
--- a/predictor.py
+++ b/predictor.py
@@ -1,4 +1,6 @@
 import csv
+import pathlib
+import platform
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
@@ -15,6 +17,8 @@ class Predictor:
         self.processor = XRayDataProcessor(processor_settings)
 
     def _load_model(self, ckpt_path: Path, device: torch.device):
+        if platform.system() != "Windows":
+            pathlib.WindowsPath = pathlib.PosixPath
         ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
         num_classes = ckpt.get("num_classes", len(ckpt.get("class_names", [])) or 3)
         in_ch = 3 if self.processor_settings.to_rgb else 1

--- a/trainer.py
+++ b/trainer.py
@@ -148,7 +148,7 @@ class Trainer:
                     torch.save(
                         {
                             "model_state_dict": self.model.state_dict(),
-                            "settings": self.config.model_dump(),
+                            "settings": self.config.model_dump(mode="json"),
                             "class_names": self.class_names,
                         },
                         ckpt_path,
@@ -166,7 +166,7 @@ class Trainer:
             torch.save(
                 {
                     "model_state_dict": self.model.state_dict(),
-                    "settings": self.config.model_dump(),
+                    "settings": self.config.model_dump(mode="json"),
                     "class_names": self.class_names,
                 },
                 ckpt_path,


### PR DESCRIPTION
## Summary
- Map `pathlib.WindowsPath` to `PosixPath` on non-Windows systems to load checkpoints saved on Windows
- Store trainer settings in JSON form to avoid serializing OS-specific `Path` objects

## Testing
- `python -m black predictor.py trainer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b4e8ddea48326a2a120689b8ca4a8